### PR TITLE
focusedWindow

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -10,6 +10,11 @@ void ofApp::setup(){
     winManager.setup((ofxAppGLFWWindowMulti *)ofGetWindowPtr());
     winManager.loadWindowSettings();
 
+    ofSetWindowTitle("main window");
+    winManager.createWindow();
+    winManager.setWindowTitle(1, "second window");
+    winManager.setWindowShape(1, 300, 300);
+
 }
 
 //--------------------------------------------------------------

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -2,36 +2,45 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-
-    //NOTE IF THIS DOESN'T COMPILE FOR YOU ON OS X
-    //YOU NEED TO SET THE FILE TYPE OF ofxAppGLFWWindowMulti.cpp to Objective C++ Source
-    //OR RENAME THE FILE ofxAppGLFWWindowMulti.mm
-
     winManager.setup((ofxAppGLFWWindowMulti *)ofGetWindowPtr());
     winManager.loadWindowSettings();
 
     ofSetWindowTitle("main window");
+
     winManager.createWindow();
     winManager.setWindowTitle(1, "second window");
     winManager.setWindowShape(1, 300, 300);
-    winManager.setWindowPosition(1, ofGetWidth() * 0.5, ofGetHeight() * 0.5);
+    winManager.setWindowPosition(1, 0, 0);
+
+    for (int i = 0; i < winManager.getWindowPtr()->getNumActiveWindows(); ++i) {
+        mousePos.push_back(ofPoint(0, 0));
+        windowSizes.push_back(ofPoint(0, 0));
+    }
 }
 
 //--------------------------------------------------------------
 void ofApp::update(){
-
 }
 
 //--------------------------------------------------------------
 void ofApp::draw(){
+    int activeWindow = winManager.getActiveWindowNo();
+
 	ofSetColor(255, 255, 255);
-    if( winManager.getActiveWindowNo() == 0){
+    if( activeWindow == 0){
         ofBackground(0, 0, 0);
         ofDrawBitmapString("Window 1\n'f' to toggle fullscreen\nn to open new window", -130 + ofGetWidth()/2, ofGetHeight()/2);
     }else{
         ofBackground(60, 60, 60);
         ofDrawBitmapString("Window " + ofToString(winManager.getActiveWindowNo()), -50 + ofGetWidth()/2, ofGetHeight()/2);
     }
+
+    ofCircle(mousePos[winManager.getActiveWindowNo()], 50);
+
+    ofVec2f size = winManager.getWindowPtr()->getWindowSize(activeWindow);
+    ofDrawBitmapString("size: " + ofToString(size), 30, 30);
+    ofVec2f pos = winManager.getWindowPtr()->getWindowPosition(activeWindow);
+    ofDrawBitmapString("position: " + ofToString(pos), 30, 50);
 }
 
 //--------------------------------------------------------------
@@ -57,7 +66,8 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y){
-
+    mousePos[winManager.getFocusedWindowNo()].x = x;
+    mousePos[winManager.getFocusedWindowNo()].y = y;
 }
 
 //--------------------------------------------------------------

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -14,6 +14,7 @@ void ofApp::setup(){
     winManager.createWindow();
     winManager.setWindowTitle(1, "second window");
     winManager.setWindowShape(1, 300, 300);
+    winManager.setWindowPosition(1, ofGetWidth() * 0.5, ofGetHeight() * 0.5);
 }
 
 //--------------------------------------------------------------

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -46,7 +46,7 @@ void ofApp::keyPressed(int key){
     }else if( key == 'n'){
         winManager.createWindow();
     }else if( key == 'c'){
-        winManager.closeActiveWindow();
+        winManager.closeFocusedWindow();
     }
 }
 

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -11,11 +11,6 @@ void ofApp::setup(){
     winManager.setWindowTitle(1, "second window");
     winManager.setWindowShape(1, 300, 300);
     winManager.setWindowPosition(1, 0, 0);
-
-    for (int i = 0; i < winManager.getWindowPtr()->getNumActiveWindows(); ++i) {
-        mousePos.push_back(ofPoint(0, 0));
-        windowSizes.push_back(ofPoint(0, 0));
-    }
 }
 
 //--------------------------------------------------------------
@@ -25,6 +20,11 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
     int activeWindow = winManager.getActiveWindowNo();
+    int focusedWindow = winManager.getFocusedWindowNo();
+    /*
+     draw() loops through all windows, changing the value of activeWindow
+     so we can do a comparison, or switch statement
+    */
 
 	ofSetColor(255, 255, 255);
     if( activeWindow == 0){
@@ -32,15 +32,23 @@ void ofApp::draw(){
         ofDrawBitmapString("Window 1\n'f' to toggle fullscreen\nn to open new window", -130 + ofGetWidth()/2, ofGetHeight()/2);
     }else{
         ofBackground(60, 60, 60);
-        ofDrawBitmapString("Window " + ofToString(winManager.getActiveWindowNo()), -50 + ofGetWidth()/2, ofGetHeight()/2);
+        ofDrawBitmapString("Window " + ofToString(activeWindow), -50 + ofGetWidth()/2, ofGetHeight()/2);
     }
 
-    ofCircle(mousePos[winManager.getActiveWindowNo()], 50);
-
-    ofVec2f size = winManager.getWindowPtr()->getWindowSize(activeWindow);
-    ofDrawBitmapString("size: " + ofToString(size), 30, 30);
-    ofVec2f pos = winManager.getWindowPtr()->getWindowPosition(activeWindow);
+    // Drawing on all active windows.
+    ofVec2f shape = winManager.getWindowShape(activeWindow);
+    ofDrawBitmapString("size: " + ofToString(shape), 30, 30);
+    ofVec2f pos = winManager.getWindowPosition(activeWindow);
     ofDrawBitmapString("position: " + ofToString(pos), 30, 50);
+
+    // Only draw on the focused window
+    if ( activeWindow == focusedWindow) {
+        string x = ofToString(ofGetMouseX());
+        string y = ofToString(ofGetMouseY());
+
+        ofDrawBitmapString("mouse: " + x + ", " + y, 30, 80);
+    }
+
 }
 
 //--------------------------------------------------------------
@@ -51,11 +59,20 @@ void ofApp::exit(){
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
     if( key == 'f' ){
+        // winManager provides direct access to many window functions
         winManager.toggleFullscreen(winManager.getFocusedWindowNo());
     }else if( key == 'n'){
         winManager.createWindow();
     }else if( key == 'c'){
         winManager.closeFocusedWindow();
+    }else if( key == 't'){
+        /*
+         pushWindow(windowNo) and popWindow() can switch the active window,
+         now standard oF methods will refer to that specific window
+        */
+        winManager.pushWindow(1);
+        ofLog() << "window 1 size:" << ofGetWindowSize();
+        winManager.popWindow();
     }
 }
 
@@ -66,8 +83,7 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y){
-    mousePos[winManager.getFocusedWindowNo()].x = x;
-    mousePos[winManager.getFocusedWindowNo()].y = y;
+
 }
 
 //--------------------------------------------------------------

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -14,7 +14,6 @@ void ofApp::setup(){
     winManager.createWindow();
     winManager.setWindowTitle(1, "second window");
     winManager.setWindowShape(1, 300, 300);
-
 }
 
 //--------------------------------------------------------------
@@ -42,7 +41,7 @@ void ofApp::exit(){
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
     if( key == 'f' ){
-        ofToggleFullscreen();
+        winManager.toggleFullscreen(winManager.getFocusedWindowNo());
     }else if( key == 'n'){
         winManager.createWindow();
     }else if( key == 'c'){

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -20,5 +20,8 @@ class ofApp : public ofBaseApp{
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
     
-        WindowManager winManager; 
+        WindowManager winManager;
+
+        vector<ofPoint>     mousePos;
+        vector<ofPoint>     windowSizes;
 };

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -21,7 +21,4 @@ class ofApp : public ofBaseApp{
 		void gotMessage(ofMessage msg);
     
         WindowManager winManager;
-
-        vector<ofPoint>     mousePos;
-        vector<ofPoint>     windowSizes;
 };

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -83,11 +83,11 @@ void WindowManager::toggleFullscreen(int windowNo){
 }
 
 //--------------------------------------------------------------
-void WindowManager::closeActiveWindow(){
+void WindowManager::closeFocusedWindow(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::closeActiveWindow") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::closeFocusedWindow") << " windowPtr needs to be set " << endl;
     }
-    windowPtr->closeWindow(getActiveWindowNo());
+    windowPtr->closeWindow(getFocusedWindowNo());
 }
 
 //--------------------------------------------------------------

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -50,6 +50,13 @@ void WindowManager::setWindowTitle(int windowNo, string title){
     windowPtr->setWindowTitle(windowNo, title);
 }
 
+void WindowManager::setWindowShape(int windowNo, int w, int h){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::setWindowShape") << " windowPtr needs to be set " << endl;
+    }
+    windowPtr->setWindowShape(windowNo, w, h);
+}
+
 //--------------------------------------------------------------
 void WindowManager::closeActiveWindow(){
     if( windowPtr == NULL ){

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -14,7 +14,7 @@ WindowManager::WindowManager(){
 //--------------------------------------------------------------
 void WindowManager::setup(ofxAppGLFWWindowMulti * ptr){
     if (ptr == NULL) {
-        ofLogError("WindowManager::setup") << " windowPtr needs to be set ";
+        ofLogError("WindowManager::setup") << "windowPtr needs to be set";
     }
     windowPtr = ptr;
     machineString = "default";
@@ -30,17 +30,26 @@ ofxAppGLFWWindowMulti * WindowManager::getWindowPtr(){
 
 //--------------------------------------------------------------
 int WindowManager::getActiveWindowNo(){
+    if( windowPtr == NULL ){
+        ofLogError("WindowManager::getActiveWindowNo") << "windowPtr needs to be set";
+        return -1;
+    }
     return windowPtr->getCurrentWindowNo();
 }
 
 //--------------------------------------------------------------
 int WindowManager::getFocusedWindowNo(){
+    if( windowPtr == NULL ){
+        ofLogError("WindowManager::getFocusedWindowNo") << "windowPtr needs to be set";
+        return -1;
+    }
     return windowPtr->getFocusedWindowNo();
 }
 //--------------------------------------------------------------
 void WindowManager::createWindow(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::createWindow") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::createWindow") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->addWindow();
 }
@@ -48,7 +57,8 @@ void WindowManager::createWindow(){
 //--------------------------------------------------------------
 void WindowManager::setWindowTitle(int windowNo, string title){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setWindowTitle") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::setWindowTitle") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->setWindowTitle(windowNo, title);
 }
@@ -56,7 +66,8 @@ void WindowManager::setWindowTitle(int windowNo, string title){
 //--------------------------------------------------------------
 void WindowManager::setWindowPosition(int windowNo, int x, int y){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setWindowPosition") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::setWindowPosition") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->setWindowPosition(windowNo, x, y);
 }
@@ -64,7 +75,8 @@ void WindowManager::setWindowPosition(int windowNo, int x, int y){
 //--------------------------------------------------------------
 void WindowManager::setWindowShape(int windowNo, int w, int h){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setWindowShape") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::setWindowShape") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->setWindowShape(windowNo, w, h);
 }
@@ -72,7 +84,8 @@ void WindowManager::setWindowShape(int windowNo, int w, int h){
 //--------------------------------------------------------------
 void WindowManager::setFullscreen(int windowNo, bool fullscreen){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setFullscreen") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::setFullscreen") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->setFullscreen(windowNo, fullscreen);
 }
@@ -80,7 +93,8 @@ void WindowManager::setFullscreen(int windowNo, bool fullscreen){
 //--------------------------------------------------------------
 void WindowManager::toggleFullscreen(int windowNo){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::toggleFullscreen") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::toggleFullscreen") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->toggleFullscreen(windowNo);
 }
@@ -88,7 +102,8 @@ void WindowManager::toggleFullscreen(int windowNo){
 //--------------------------------------------------------------
 void WindowManager::closeFocusedWindow(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::closeFocusedWindow") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::closeFocusedWindow") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->closeWindow(getFocusedWindowNo());
 }
@@ -96,7 +111,8 @@ void WindowManager::closeFocusedWindow(){
 //--------------------------------------------------------------
 void WindowManager::closeWindow(int which){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::closeWindow") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::closeWindow") << "windowPtr needs to be set";
+        return;
     }
     windowPtr->closeWindow(which);
 }
@@ -104,7 +120,8 @@ void WindowManager::closeWindow(int which){
 //--------------------------------------------------------------
 void WindowManager::loadWindowSettings(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::loadWindowSettings") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::loadWindowSettings") << "windowPtr needs to be set";
+        return;
     }
 
     vector < shared_ptr<AppGLFWSingleWindow> > windows = windowPtr->getWindows();
@@ -166,7 +183,8 @@ void WindowManager::loadWindowSettings(){
 //--------------------------------------------------------------
 void WindowManager::saveWindowSettings(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::saveWindowSettings") << " windowPtr needs to be set " << endl;
+        ofLogError("WindowManager::saveWindowSettings") << "windowPtr needs to be set";
+        return;
     }
     
     if( ofDirectory::doesDirectoryExist("settings") == false){

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -31,6 +31,10 @@ int WindowManager::getActiveWindowNo(){
 }
 
 //--------------------------------------------------------------
+int WindowManager::getFocusedWindowNo(){
+    return windowPtr->getFocusedWindowNo();
+}
+//--------------------------------------------------------------
 void WindowManager::createWindow(){
     if( windowPtr == NULL ){
         ofLogError("WindowManager::createWindow") << " windowPtr needs to be set " << endl;

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -8,7 +8,7 @@
 #include "WindowManager.h"
 
 WindowManager::WindowManager(){
-    windowPtr = NULL; 
+    windowPtr = NULL;
 }
 
 //--------------------------------------------------------------
@@ -154,35 +154,35 @@ void WindowManager::loadWindowSettings(){
     windowPosXml.clear();
     if(windowPosXml.loadFile("settings/Window/windowSettings-"+machineString+".xml")){
         int numTags = windowPosXml.getNumTags("window");
-        
+
         for(int i = windows.size(); i < numTags; i++){
             windowPtr->addWindow("Window "+ofToString(i,0), 100, 100, 400, 400, false);
         }
-        
+
         windows = windowPtr->getWindows();
-        
+
         int numToLoad = MIN(windows.size(), numTags);
-        
+
         ofRectangle winBounds;
         ofRectangle fsBounds;
-        
+
         for(int i = 0; i < numToLoad; i++){
             if( windowPosXml.pushTag("window", i) ){
-        
+
                 fsBounds.x           = windowPosXml.getAttribute("fullscreen-rect", "x", (int)windows[i]->fullScreenBounds.x);
                 fsBounds.y           = windowPosXml.getAttribute("fullscreen-rect", "y", (int)windows[i]->fullScreenBounds.y);
                 fsBounds.width       = windowPosXml.getAttribute("fullscreen-rect", "width", (int)windows[i]->fullScreenBounds.width);
                 fsBounds.height      = windowPosXml.getAttribute("fullscreen-rect", "height", (int)windows[i]->fullScreenBounds.height);
-                
+
                 winBounds.x          = windowPosXml.getAttribute("window-rect", "x", (int)windows[i]->windowBounds.x);
                 winBounds.y          = windowPosXml.getAttribute("window-rect", "y", (int)windows[i]->windowBounds.y);
                 winBounds.width      = windowPosXml.getAttribute("window-rect", "width", (int)windows[i]->windowBounds.width);
                 winBounds.height     = windowPosXml.getAttribute("window-rect", "height", (int)windows[i]->windowBounds.height);
 
                 windowPosXml.popTag();
-                
+
                 if( windowPtr->pushWindow(i) ){
-                
+
                     if( windowPosXml.getAttribute("window", "fullscreen", 0, i) ){
                         ofSetFullscreen(false);
                         ofSetWindowPosition(fsBounds.x+1, fsBounds.y);
@@ -211,40 +211,40 @@ void WindowManager::saveWindowSettings(){
         ofLogError("WindowManager::saveWindowSettings") << "windowPtr needs to be set";
         return;
     }
-    
+
     if( ofDirectory::doesDirectoryExist("settings") == false){
         ofDirectory::createDirectory("settings");
     }
     if( ofDirectory::doesDirectoryExist("settings/Window") == false){
         ofDirectory::createDirectory("settings/Window");
     }
-    
+
     vector < shared_ptr <AppGLFWSingleWindow> > windows = windowPtr->getWindows();
-    
+
     windowPosXml.loadFile("settings/Window/windowSettings-"+machineString+".xml");
     windowPosXml.clear();
     for(int i = 0; i < windows.size(); i++){
-    
+
         if( windows[i]->windowPtr == NULL )continue;
-        
+
         windowPosXml.addTag("window");
         if( windowPosXml.pushTag("window", i) ){
-        
+
             //force update of pos info
             if( windowPtr->pushWindow(i) ){
                 windowPtr->getWindowSize();
                 windowPtr->getWindowPosition();
                 windowPtr->popWindow();
             }
-            
+
             windowPosXml.addTag("fullscreen-rect");
-            windowPosXml.addTag("window-rect"); 
+            windowPosXml.addTag("window-rect");
 
             windowPosXml.addAttribute("fullscreen-rect", "x", (int)windows[i]->fullScreenBounds.x, 0);
             windowPosXml.addAttribute("fullscreen-rect", "y", (int)windows[i]->fullScreenBounds.y, 0);
             windowPosXml.addAttribute("fullscreen-rect", "width", (int)windows[i]->fullScreenBounds.width, 0);
             windowPosXml.addAttribute("fullscreen-rect", "height", (int)windows[i]->fullScreenBounds.height, 0);
-            
+
             windowPosXml.addAttribute("window-rect", "x", (int)windows[i]->windowBounds.x, 0);
             windowPosXml.addAttribute("window-rect", "y", (int)windows[i]->windowBounds.y, 0);
             windowPosXml.addAttribute("window-rect", "width", (int)windows[i]->windowBounds.width, 0);
@@ -254,6 +254,6 @@ void WindowManager::saveWindowSettings(){
             windowPosXml.addAttribute("window", "fullscreen", windows[i]->bFullscreen, i);
         }
     }
-    
+
     windowPosXml.saveFile("settings/Window/windowSettings-"+machineString+".xml");
 }

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -60,6 +60,24 @@ void WindowManager::createWindow(){
 }
 
 //--------------------------------------------------------------
+void WindowManager::pushWindow(int windowNo){
+    if( windowPtr == NULL ){
+        ofLogError("WindowManager::pushWindow") << UNSET_ERR;
+        return;
+    }
+    windowPtr->pushWindow(windowNo);
+}
+
+//--------------------------------------------------------------
+void WindowManager::popWindow(){
+    if( windowPtr == NULL ){
+        ofLogError("WindowManager::popWindow") << UNSET_ERR;
+        return;
+    }
+    windowPtr->popWindow();
+}
+
+//--------------------------------------------------------------
 void WindowManager::setWindowTitle(int windowNo, string title){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setWindowTitle") << UNSET_ERR;

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -43,6 +43,14 @@ void WindowManager::createWindow(){
 }
 
 //--------------------------------------------------------------
+void WindowManager::setWindowTitle(int windowNo, string title){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::setWindowTitle") << " windowPtr needs to be set " << endl;
+    }
+    windowPtr->setWindowTitle(windowNo, title);
+}
+
+//--------------------------------------------------------------
 void WindowManager::closeActiveWindow(){
     if( windowPtr == NULL ){
         ofLogError("WindowManager::closeActiveWindow") << " windowPtr needs to be set " << endl;

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -101,6 +101,7 @@ ofPoint WindowManager::getWindowShape(int windowNo){
         ofLogError("WindowManager::getWindowShape") << UNSET_ERR;
         return ofPoint(0, 0);
     }
+    return windowPtr->getWindowSize(windowNo);
 }
 //--------------------------------------------------------------
 ofPoint WindowManager::getScreenSize(int windowNo){

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -125,6 +125,16 @@ void WindowManager::toggleFullscreen(int windowNo){
 }
 
 //--------------------------------------------------------------
+int WindowManager::getWindowMode(int windowMode){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::getWindowMode") << "windowPtr needs to be set";
+        return OF_WINDOW;
+    }
+
+    return windowPtr->getWindowMode(windowMode);
+}
+
+//--------------------------------------------------------------
 void WindowManager::closeFocusedWindow(){
     if( windowPtr == NULL ){
         ofLogError("WindowManager::closeFocusedWindow") << "windowPtr needs to be set";

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -50,11 +50,28 @@ void WindowManager::setWindowTitle(int windowNo, string title){
     windowPtr->setWindowTitle(windowNo, title);
 }
 
+//--------------------------------------------------------------
 void WindowManager::setWindowShape(int windowNo, int w, int h){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setWindowShape") << " windowPtr needs to be set " << endl;
     }
     windowPtr->setWindowShape(windowNo, w, h);
+}
+
+//--------------------------------------------------------------
+void WindowManager::setFullscreen(int windowNo, bool fullscreen){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::setFullscreen") << " windowPtr needs to be set " << endl;
+    }
+    windowPtr->setFullscreen(windowNo, fullscreen);
+}
+
+//--------------------------------------------------------------
+void WindowManager::toggleFullscreen(int windowNo){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::toggleFullscreen") << " windowPtr needs to be set " << endl;
+    }
+    windowPtr->toggleFullscreen(windowNo);
 }
 
 //--------------------------------------------------------------

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -64,6 +64,15 @@ void WindowManager::setWindowTitle(int windowNo, string title){
 }
 
 //--------------------------------------------------------------
+ofPoint WindowManager::getWindowPosition(int windowNo){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::getWindowPosition") << "windowPtr needs to be set";
+        return ofPoint(0, 0);
+    }
+    return windowPtr->getWindowPosition(windowNo);
+}
+
+//--------------------------------------------------------------
 void WindowManager::setWindowPosition(int windowNo, int x, int y){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setWindowPosition") << "windowPtr needs to be set";

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -5,6 +5,8 @@
 //
 //
 
+#define UNSET_ERR "windowPtr needs to be set";
+
 #include "WindowManager.h"
 
 WindowManager::WindowManager(){
@@ -14,7 +16,7 @@ WindowManager::WindowManager(){
 //--------------------------------------------------------------
 void WindowManager::setup(ofxAppGLFWWindowMulti * ptr){
     if (ptr == NULL) {
-        ofLogError("WindowManager::setup") << "windowPtr needs to be set";
+        ofLogError("WindowManager::setup") << UNSET_ERR;
     }
     windowPtr = ptr;
     machineString = "default";
@@ -25,13 +27,16 @@ void WindowManager::setup(ofxAppGLFWWindowMulti * ptr){
 
 //--------------------------------------------------------------
 ofxAppGLFWWindowMulti * WindowManager::getWindowPtr(){
+    if ( windowPtr == NULL) {
+        ofLogError("WindowManager::getWindowPtr") << UNSET_ERR;
+    }
     return windowPtr;
 }
 
 //--------------------------------------------------------------
 int WindowManager::getActiveWindowNo(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::getActiveWindowNo") << "windowPtr needs to be set";
+        ofLogError("WindowManager::getActiveWindowNo") << UNSET_ERR;
         return -1;
     }
     return windowPtr->getCurrentWindowNo();
@@ -40,7 +45,7 @@ int WindowManager::getActiveWindowNo(){
 //--------------------------------------------------------------
 int WindowManager::getFocusedWindowNo(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::getFocusedWindowNo") << "windowPtr needs to be set";
+        ofLogError("WindowManager::getFocusedWindowNo") << UNSET_ERR;
         return -1;
     }
     return windowPtr->getFocusedWindowNo();
@@ -48,7 +53,7 @@ int WindowManager::getFocusedWindowNo(){
 //--------------------------------------------------------------
 void WindowManager::createWindow(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::createWindow") << "windowPtr needs to be set";
+        ofLogError("WindowManager::createWindow") << UNSET_ERR;
         return;
     }
     windowPtr->addWindow();
@@ -57,7 +62,7 @@ void WindowManager::createWindow(){
 //--------------------------------------------------------------
 void WindowManager::setWindowTitle(int windowNo, string title){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setWindowTitle") << "windowPtr needs to be set";
+        ofLogError("WindowManager::setWindowTitle") << UNSET_ERR;
         return;
     }
     windowPtr->setWindowTitle(windowNo, title);
@@ -66,7 +71,7 @@ void WindowManager::setWindowTitle(int windowNo, string title){
 //--------------------------------------------------------------
 void WindowManager::setWindowPosition(int windowNo, int x, int y){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setWindowPosition") << "windowPtr needs to be set";
+        ofLogError("WindowManager::setWindowPosition") << UNSET_ERR;
         return;
     }
     windowPtr->setWindowPosition(windowNo, x, y);
@@ -75,7 +80,7 @@ void WindowManager::setWindowPosition(int windowNo, int x, int y){
 //--------------------------------------------------------------
 void WindowManager::setWindowShape(int windowNo, int w, int h){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setWindowShape") << "windowPtr needs to be set";
+        ofLogError("WindowManager::setWindowShape") << UNSET_ERR;
         return;
     }
     windowPtr->setWindowShape(windowNo, w, h);
@@ -84,7 +89,7 @@ void WindowManager::setWindowShape(int windowNo, int w, int h){
 //--------------------------------------------------------------
 ofPoint WindowManager::getWindowPosition(int windowNo){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::getWindowPosition") << "windowPtr needs to be set";
+        ofLogError("WindowManager::getWindowPosition") << UNSET_ERR;
         return ofPoint(0, 0);
     }
     return windowPtr->getWindowPosition(windowNo);
@@ -93,14 +98,14 @@ ofPoint WindowManager::getWindowPosition(int windowNo){
 //--------------------------------------------------------------
 ofPoint WindowManager::getWindowShape(int windowNo){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::getWindowShape") << "windowPtr needs to be set";
+        ofLogError("WindowManager::getWindowShape") << UNSET_ERR;
         return ofPoint(0, 0);
     }
 }
 //--------------------------------------------------------------
 ofPoint WindowManager::getScreenSize(int windowNo){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::getScreenSize") << "windowPtr needs to be set";
+        ofLogError("WindowManager::getScreenSize") << UNSET_ERR;
         return ofPoint(0, 0);
     }
     return windowPtr->getScreenSize(windowNo);
@@ -109,7 +114,7 @@ ofPoint WindowManager::getScreenSize(int windowNo){
 //--------------------------------------------------------------
 void WindowManager::setFullscreen(int windowNo, bool fullscreen){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::setFullscreen") << "windowPtr needs to be set";
+        ofLogError("WindowManager::setFullscreen") << UNSET_ERR;
         return;
     }
     windowPtr->setFullscreen(windowNo, fullscreen);
@@ -118,7 +123,7 @@ void WindowManager::setFullscreen(int windowNo, bool fullscreen){
 //--------------------------------------------------------------
 void WindowManager::toggleFullscreen(int windowNo){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::toggleFullscreen") << "windowPtr needs to be set";
+        ofLogError("WindowManager::toggleFullscreen") << UNSET_ERR;
         return;
     }
     windowPtr->toggleFullscreen(windowNo);
@@ -127,7 +132,7 @@ void WindowManager::toggleFullscreen(int windowNo){
 //--------------------------------------------------------------
 int WindowManager::getWindowMode(int windowMode){
     if (windowPtr == NULL) {
-        ofLogError("WindowManager::getWindowMode") << "windowPtr needs to be set";
+        ofLogError("WindowManager::getWindowMode") << UNSET_ERR;
         return OF_WINDOW;
     }
 
@@ -137,7 +142,7 @@ int WindowManager::getWindowMode(int windowMode){
 //--------------------------------------------------------------
 void WindowManager::closeFocusedWindow(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::closeFocusedWindow") << "windowPtr needs to be set";
+        ofLogError("WindowManager::closeFocusedWindow") << UNSET_ERR;
         return;
     }
     windowPtr->closeWindow(getFocusedWindowNo());
@@ -146,7 +151,7 @@ void WindowManager::closeFocusedWindow(){
 //--------------------------------------------------------------
 void WindowManager::closeWindow(int which){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::closeWindow") << "windowPtr needs to be set";
+        ofLogError("WindowManager::closeWindow") << UNSET_ERR;
         return;
     }
     windowPtr->closeWindow(which);
@@ -155,7 +160,7 @@ void WindowManager::closeWindow(int which){
 //--------------------------------------------------------------
 void WindowManager::loadWindowSettings(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::loadWindowSettings") << "windowPtr needs to be set";
+        ofLogError("WindowManager::loadWindowSettings") << UNSET_ERR;
         return;
     }
 
@@ -218,7 +223,7 @@ void WindowManager::loadWindowSettings(){
 //--------------------------------------------------------------
 void WindowManager::saveWindowSettings(){
     if( windowPtr == NULL ){
-        ofLogError("WindowManager::saveWindowSettings") << "windowPtr needs to be set";
+        ofLogError("WindowManager::saveWindowSettings") << UNSET_ERR;
         return;
     }
 

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -98,6 +98,15 @@ void WindowManager::setWindowShape(int windowNo, int w, int h){
 }
 
 //--------------------------------------------------------------
+ofPoint WindowManager::getScreenSize(int windowNo){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::getScreenSize") << "windowPtr needs to be set";
+        return ofPoint(0, 0);
+    }
+    return windowPtr->getScreenSize(windowNo);
+}
+
+//--------------------------------------------------------------
 void WindowManager::setFullscreen(int windowNo, bool fullscreen){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setFullscreen") << "windowPtr needs to be set";

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -82,6 +82,13 @@ void WindowManager::setWindowPosition(int windowNo, int x, int y){
 }
 
 //--------------------------------------------------------------
+ofPoint WindowManager::getWindowShape(int windowNo){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::getWindowShape") << "windowPtr needs to be set";
+        return ofPoint(0, 0);
+    }
+}
+//--------------------------------------------------------------
 void WindowManager::setWindowShape(int windowNo, int w, int h){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setWindowShape") << "windowPtr needs to be set";

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -13,6 +13,9 @@ WindowManager::WindowManager(){
 
 //--------------------------------------------------------------
 void WindowManager::setup(ofxAppGLFWWindowMulti * ptr){
+    if (ptr == NULL) {
+        ofLogError("WindowManager::setup") << " windowPtr needs to be set ";
+    }
     windowPtr = ptr;
     machineString = "default";
     if( getenv("USER") != NULL ) {

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -51,6 +51,14 @@ void WindowManager::setWindowTitle(int windowNo, string title){
 }
 
 //--------------------------------------------------------------
+void WindowManager::setWindowPosition(int windowNo, int x, int y){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::setWindowPosition") << " windowPtr needs to be set " << endl;
+    }
+    windowPtr->setWindowPosition(windowNo, x, y);
+}
+
+//--------------------------------------------------------------
 void WindowManager::setWindowShape(int windowNo, int w, int h){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setWindowShape") << " windowPtr needs to be set " << endl;

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -64,15 +64,6 @@ void WindowManager::setWindowTitle(int windowNo, string title){
 }
 
 //--------------------------------------------------------------
-ofPoint WindowManager::getWindowPosition(int windowNo){
-    if (windowPtr == NULL) {
-        ofLogError("WindowManager::getWindowPosition") << "windowPtr needs to be set";
-        return ofPoint(0, 0);
-    }
-    return windowPtr->getWindowPosition(windowNo);
-}
-
-//--------------------------------------------------------------
 void WindowManager::setWindowPosition(int windowNo, int x, int y){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setWindowPosition") << "windowPtr needs to be set";
@@ -82,13 +73,6 @@ void WindowManager::setWindowPosition(int windowNo, int x, int y){
 }
 
 //--------------------------------------------------------------
-ofPoint WindowManager::getWindowShape(int windowNo){
-    if (windowPtr == NULL) {
-        ofLogError("WindowManager::getWindowShape") << "windowPtr needs to be set";
-        return ofPoint(0, 0);
-    }
-}
-//--------------------------------------------------------------
 void WindowManager::setWindowShape(int windowNo, int w, int h){
     if (windowPtr == NULL) {
         ofLogError("WindowManager::setWindowShape") << "windowPtr needs to be set";
@@ -97,6 +81,22 @@ void WindowManager::setWindowShape(int windowNo, int w, int h){
     windowPtr->setWindowShape(windowNo, w, h);
 }
 
+//--------------------------------------------------------------
+ofPoint WindowManager::getWindowPosition(int windowNo){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::getWindowPosition") << "windowPtr needs to be set";
+        return ofPoint(0, 0);
+    }
+    return windowPtr->getWindowPosition(windowNo);
+}
+
+//--------------------------------------------------------------
+ofPoint WindowManager::getWindowShape(int windowNo){
+    if (windowPtr == NULL) {
+        ofLogError("WindowManager::getWindowShape") << "windowPtr needs to be set";
+        return ofPoint(0, 0);
+    }
+}
 //--------------------------------------------------------------
 ofPoint WindowManager::getScreenSize(int windowNo){
     if (windowPtr == NULL) {

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -23,7 +23,8 @@ class WindowManager{
         void closeActiveWindow();
         
         int getActiveWindowNo();
-    
+        int getFocusedWindowNo();
+
         ofxAppGLFWWindowMulti * getWindowPtr(); 
     
     protected:

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -21,6 +21,8 @@ class WindowManager{
         void createWindow();
         void setWindowTitle(int windowNo, string title);
         void setWindowShape(int windowNo, int w, int h);
+        void setFullscreen(int windowNo, bool fullscreen);
+        void toggleFullscreen(int windowNo);
         void closeWindow(int which);
         void closeActiveWindow();
         

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -33,6 +33,8 @@ class WindowManager{
         void setFullscreen(int windowNo, bool fullscreen);
         void toggleFullscreen(int windowNo);
 
+        int getWindowMode(int windowNo);
+
         void closeWindow(int which);
         void closeFocusedWindow();
 

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -12,12 +12,12 @@
 
 class WindowManager{
     public:
-    
-        WindowManager(); 
+
+        WindowManager();
         void setup(ofxAppGLFWWindowMulti * ptr);
         void loadWindowSettings();
         void saveWindowSettings();
-    
+
         void createWindow();
         void setWindowTitle(int windowNo, string title);
         ofPoint getWindowPosition(int windowNo);
@@ -29,14 +29,14 @@ class WindowManager{
         void toggleFullscreen(int windowNo);
         void closeWindow(int which);
         void closeFocusedWindow();
-        
+
         int getActiveWindowNo();
         int getFocusedWindowNo();
 
-        ofxAppGLFWWindowMulti * getWindowPtr(); 
-    
+        ofxAppGLFWWindowMulti * getWindowPtr();
+
     protected:
         ofxAppGLFWWindowMulti * windowPtr;
         ofxXmlSettings windowPosXml;
-        string machineString; 
+        string machineString;
 };

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -20,6 +20,7 @@ class WindowManager{
     
         void createWindow();
         void setWindowTitle(int windowNo, string title);
+        void setWindowPosition(int windowNo, int x, int y);
         void setWindowShape(int windowNo, int w, int h);
         void setFullscreen(int windowNo, bool fullscreen);
         void toggleFullscreen(int windowNo);

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -19,14 +19,18 @@ class WindowManager{
         void saveWindowSettings();
 
         void createWindow();
+
         void setWindowTitle(int windowNo, string title);
-        ofPoint getWindowPosition(int windowNo);
         void setWindowPosition(int windowNo, int x, int y);
-        ofPoint getWindowShape(int windowNo);
         void setWindowShape(int windowNo, int w, int h);
+
+        ofPoint getWindowPosition(int windowNo);
+        ofPoint getWindowShape(int windowNo);
         ofPoint getScreenSize(int windowNo);
+
         void setFullscreen(int windowNo, bool fullscreen);
         void toggleFullscreen(int windowNo);
+
         void closeWindow(int which);
         void closeFocusedWindow();
 

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -22,6 +22,7 @@ class WindowManager{
         void setWindowTitle(int windowNo, string title);
         ofPoint getWindowPosition(int windowNo);
         void setWindowPosition(int windowNo, int x, int y);
+        ofPoint getWindowShape(int windowNo);
         void setWindowShape(int windowNo, int w, int h);
         void setFullscreen(int windowNo, bool fullscreen);
         void toggleFullscreen(int windowNo);

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -20,6 +20,7 @@ class WindowManager{
     
         void createWindow();
         void setWindowTitle(int windowNo, string title);
+        ofPoint getWindowPosition(int windowNo);
         void setWindowPosition(int windowNo, int x, int y);
         void setWindowShape(int windowNo, int w, int h);
         void setFullscreen(int windowNo, bool fullscreen);

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -24,6 +24,7 @@ class WindowManager{
         void setWindowPosition(int windowNo, int x, int y);
         ofPoint getWindowShape(int windowNo);
         void setWindowShape(int windowNo, int w, int h);
+        ofPoint getScreenSize(int windowNo);
         void setFullscreen(int windowNo, bool fullscreen);
         void toggleFullscreen(int windowNo);
         void closeWindow(int which);

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -20,6 +20,7 @@ class WindowManager{
     
         void createWindow();
         void setWindowTitle(int windowNo, string title);
+        void setWindowShape(int windowNo, int w, int h);
         void closeWindow(int which);
         void closeActiveWindow();
         

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -22,6 +22,9 @@ class WindowManager{
 
         void createWindow();
 
+        void pushWindow(int windowNo);
+        void popWindow();
+
         void setWindowTitle(int windowNo, string title);
         void setWindowPosition(int windowNo, int x, int y);
         void setWindowShape(int windowNo, int w, int h);

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -19,6 +19,7 @@ class WindowManager{
         void saveWindowSettings();
     
         void createWindow();
+        void setWindowTitle(int windowNo, string title);
         void closeWindow(int which);
         void closeActiveWindow();
         

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -15,8 +15,10 @@ class WindowManager{
 
         WindowManager();
         void setup(ofxAppGLFWWindowMulti * ptr);
-        void loadWindowSettings();
-        void saveWindowSettings();
+        ofxAppGLFWWindowMulti * getWindowPtr();
+
+        int getActiveWindowNo();
+        int getFocusedWindowNo();
 
         void createWindow();
 
@@ -34,10 +36,8 @@ class WindowManager{
         void closeWindow(int which);
         void closeFocusedWindow();
 
-        int getActiveWindowNo();
-        int getFocusedWindowNo();
-
-        ofxAppGLFWWindowMulti * getWindowPtr();
+        void loadWindowSettings();
+        void saveWindowSettings();
 
     protected:
         ofxAppGLFWWindowMulti * windowPtr;

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -25,7 +25,7 @@ class WindowManager{
         void setFullscreen(int windowNo, bool fullscreen);
         void toggleFullscreen(int windowNo);
         void closeWindow(int which);
-        void closeActiveWindow();
+        void closeFocusedWindow();
         
         int getActiveWindowNo();
         int getFocusedWindowNo();

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -116,6 +116,7 @@ public:
 	int getWidth();
 
 	ofVec3f		getWindowSize();
+    ofVec3f		getWindowSize(int winNo);
 	ofVec3f		getScreenSize();
 	ofVec3f 	getWindowPosition();
 
@@ -199,7 +200,8 @@ private:
 	bool			bDoubleBuffered;
     bool            bMultiWindowFullscreen;
     bool            isSetup; 
-    
+
+    ofPoint         updateWindowSize(int winNo);
 	int				getCurrentMonitor();
 	
 	static ofxAppGLFWWindowMulti	* instance;

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -118,12 +118,12 @@ public:
     int getWidth();
 
     int         getWindowMonitor(int windowNo);
-    ofVec3f     getWindowSize(int windowNo);
-    ofVec3f     getWindowSize();
-    ofVec3f     getScreenSize(int windowNo);
-    ofVec3f     getScreenSize();
-    ofVec3f     getWindowPosition(int windowNo);
-    ofVec3f     getWindowPosition();
+    ofPoint     getWindowSize(int windowNo);
+    ofPoint     getWindowSize();
+    ofPoint     getScreenSize(int windowNo);
+    ofPoint     getScreenSize();
+    ofPoint     getWindowPosition(int windowNo);
+    ofPoint     getWindowPosition();
 
     void setWindowTitle(int windowNo, string title);
 	void setWindowTitle(string title);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -34,7 +34,7 @@ class AppGLFWSingleWindow{
             bInitialized = false;
             windowPtr = NULL;
         }
-    
+
         ofRectangle getCurrentBounds(){
             if( bFullscreen ){
                 return fullScreenBounds;
@@ -42,21 +42,21 @@ class AppGLFWSingleWindow{
                 return windowBounds;
             }
         }
-    
+
         bool bFullscreen;
         bool bMainWindow;
         bool bInFocus;
         bool bInitialized;
         bool bClosed;
         int windowNo;
-    
-        string windowName; 
+
+        string windowName;
         GLFWwindow* windowPtr;
-    
+
         ofRectangle windowBounds;
         ofRectangle fullScreenBounds;
-    
-        ofPoint mousePt; 
+
+        ofPoint mousePt;
 };
 
 class ofxAppGLFWWindowMulti : public ofAppBaseWindow {
@@ -86,12 +86,12 @@ public:
     int getCurrentWindowNo();
     int getFocusedWindowNo();
     bool isWindowInFocus(int windowNo);
-    
+
     int addWindow(string windowName = "", float x = 0, float y = 0, float w = 1024, float h = 768, bool bFullscreen = false);
     bool closeWindow(int windowNo);
     int getNumWindows();
     int getNumActiveWindows();
-    
+
     //Note: push/pop window should always be used together.
     //sets active the window specified by windowNo - all OF window commands will now refer to this window.
     bool pushWindow(int windowNo);
@@ -101,7 +101,7 @@ public:
     vector < shared_ptr <AppGLFWSingleWindow> > getWindows();
     //end multi window stuff
 
-    
+
     // this functions are only meant to be called from inside OF don't call them from your code
 	void setOpenGLVersion(int major, int minor);
 	void setupOpenGL(int w, int h, int screenMode);
@@ -210,11 +210,11 @@ private:
 	int 			nFramesSinceWindowResized;
 	bool			bDoubleBuffered;
     bool            bMultiWindowFullscreen;
-    bool            isSetup; 
+    bool            isSetup;
 
     ofPoint         updateWindowSize(int windowNo);
 	int				getCurrentMonitor();
-	
+
 	static ofxAppGLFWWindowMulti	* instance;
 	static ofBaseApp *	ofAppPtr;
 

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -135,8 +135,8 @@ public:
 	void			setOrientation(ofOrientation orientation);
 	ofOrientation	getOrientation();
 
-    int         getWindowMode(int windowNo);
-    int         getWindowMode();
+    int             getWindowMode(int windowNo);
+    int             getWindowMode();
 
     void		setFullscreen(int windowNo, bool fullscreen);
 	void		setFullscreen(bool fullscreen);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -125,6 +125,7 @@ public:
     ofVec3f     getWindowPosition(int windowNo);
     ofVec3f     getWindowPosition();
 
+    void setWindowTitle(int windowNo, string title);
 	void setWindowTitle(string title);
     void setWindowPosition(int windowNo, int x, int y);
 	void setWindowPosition(int x, int y);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -117,6 +117,7 @@ public:
     int getWidth(int winNo);
     int getWidth();
 
+    int         getWindowMonitor(int winNo);
     ofVec3f     getWindowSize(int winNo);
     ofVec3f     getWindowSize();
     ofVec3f     getScreenSize(int winNo);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -126,6 +126,7 @@ public:
     ofVec3f     getWindowPosition();
 
 	void setWindowTitle(string title);
+    void setWindowPosition(int windowNo, int x, int y);
 	void setWindowPosition(int x, int y);
 	void setWindowShape(int w, int h);
 

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -112,8 +112,10 @@ public:
 	void hideCursor();
 	void showCursor();
 
-	int getHeight();
-	int getWidth();
+    int getHeight(int winNo);
+    int getHeight();
+    int getWidth(int winNo);
+    int getWidth();
 
 	ofVec3f		getWindowSize();
     ofVec3f		getWindowSize(int winNo);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -85,7 +85,7 @@ public:
     //begin multi window stuff
     int getCurrentWindowNo();
     int getFocusedWindowNo();
-    bool isWindowInFocus(int winNo);
+    bool isWindowInFocus(int windowNo);
     
     int addWindow(string windowName = "", float x = 0, float y = 0, float w = 1024, float h = 768, bool bFullscreen = false);
     bool closeWindow(int windowNo);
@@ -112,17 +112,17 @@ public:
 	void hideCursor();
 	void showCursor();
 
-    int getHeight(int winNo);
+    int getHeight(int windowNo);
     int getHeight();
-    int getWidth(int winNo);
+    int getWidth(int windowNo);
     int getWidth();
 
-    int         getWindowMonitor(int winNo);
-    ofVec3f     getWindowSize(int winNo);
+    int         getWindowMonitor(int windowNo);
+    ofVec3f     getWindowSize(int windowNo);
     ofVec3f     getWindowSize();
-    ofVec3f     getScreenSize(int winNo);
+    ofVec3f     getScreenSize(int windowNo);
     ofVec3f     getScreenSize();
-    ofVec3f     getWindowPosition(int winNo);
+    ofVec3f     getWindowPosition(int windowNo);
     ofVec3f     getWindowPosition();
 
 	void setWindowTitle(string title);
@@ -132,7 +132,7 @@ public:
 	void			setOrientation(ofOrientation orientation);
 	ofOrientation	getOrientation();
 
-    int         getWindowMode(int winNo);
+    int         getWindowMode(int windowNo);
     int         getWindowMode();
 
 	void		setFullscreen(bool fullscreen);
@@ -207,7 +207,7 @@ private:
     bool            bMultiWindowFullscreen;
     bool            isSetup; 
 
-    ofPoint         updateWindowSize(int winNo);
+    ofPoint         updateWindowSize(int windowNo);
 	int				getCurrentMonitor();
 	
 	static ofxAppGLFWWindowMulti	* instance;

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -120,6 +120,7 @@ public:
 	ofVec3f		getWindowSize();
     ofVec3f		getWindowSize(int winNo);
 	ofVec3f		getScreenSize();
+    ofVec3f		getScreenSize(int winNo);
 	ofVec3f 	getWindowPosition();
 
 	void setWindowTitle(string title);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -117,11 +117,12 @@ public:
     int getWidth(int winNo);
     int getWidth();
 
-	ofVec3f		getWindowSize();
-    ofVec3f		getWindowSize(int winNo);
-	ofVec3f		getScreenSize();
-    ofVec3f		getScreenSize(int winNo);
-	ofVec3f 	getWindowPosition();
+    ofVec3f     getWindowSize(int winNo);
+    ofVec3f     getWindowSize();
+    ofVec3f     getScreenSize(int winNo);
+    ofVec3f     getScreenSize();
+    ofVec3f     getWindowPosition(int winNo);
+    ofVec3f     getWindowPosition();
 
 	void setWindowTitle(string title);
 	void setWindowPosition(int x, int y);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -84,6 +84,7 @@ public:
 
     //begin multi window stuff
     int getCurrentWindowNo();
+    int getFocusedWindowNo();
     bool isWindowInFocus(int winNo);
     
     int addWindow(string windowName = "", float x = 0, float y = 0, float w = 1024, float h = 768, bool bFullscreen = false);
@@ -161,7 +162,7 @@ public:
 #endif
 
     //so we get set the correct window for events in key pressed mouse etc.
-    void setCurrentWindowToWin(GLFWwindow * windowP_); 
+    void setFocusedWindow(GLFWwindow * windowP_);
 
 private:
 	// callbacks
@@ -203,8 +204,9 @@ private:
 	
 	static ofxAppGLFWWindowMulti	* instance;
 	static ofBaseApp *	ofAppPtr;
-    
-    int currentWindow; 
+
+    int currentWindow;
+    int focusedWindow;
     vector < shared_ptr <AppGLFWSingleWindow> > windows;
     vector <int> windowStack;
 

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -129,6 +129,7 @@ public:
 	void setWindowTitle(string title);
     void setWindowPosition(int windowNo, int x, int y);
 	void setWindowPosition(int x, int y);
+    void setWindowShape(int windowNo, int w, int h);
 	void setWindowShape(int w, int h);
 
 	void			setOrientation(ofOrientation orientation);

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -138,7 +138,9 @@ public:
     int         getWindowMode(int windowNo);
     int         getWindowMode();
 
+    void		setFullscreen(int windowNo, bool fullscreen);
 	void		setFullscreen(bool fullscreen);
+    void		toggleFullscreen(int windowNo);
 	void		toggleFullscreen();
 
 	void		enableSetupScreen();

--- a/src/ofxAppGLFWWindowMulti.h
+++ b/src/ofxAppGLFWWindowMulti.h
@@ -132,7 +132,8 @@ public:
 	void			setOrientation(ofOrientation orientation);
 	ofOrientation	getOrientation();
 
-	int			getWindowMode();
+    int         getWindowMode(int winNo);
+    int         getWindowMode();
 
 	void		setFullscreen(bool fullscreen);
 	void		toggleFullscreen();

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -1137,18 +1137,10 @@ void ofxAppGLFWWindowMulti::mouse_cb(GLFWwindow* windowP_, int button, int state
     ofPoint mousePt = instance->windows[instance->focusedWindow]->mousePt;
 
 	if (state == GLFW_PRESS){
-        if( instance->focusedWindow == 0 ){
-            ofNotifyMousePressed(mousePt.x, mousePt.y, button);
-        }else{
-            ofAppPtr->mousePressed(mousePt.x, mousePt.y, button);
-        }
+        ofNotifyMousePressed(mousePt.x, mousePt.y, button);
 		instance->buttonPressed=true;
 	} else if (state == GLFW_RELEASE) {
-        if( instance->focusedWindow == 0 ){
-            ofNotifyMouseReleased(mousePt.x, mousePt.y, button);
-        }else{
-            ofAppPtr->mouseReleased(mousePt.x, mousePt.y, button);
-        }
+        ofNotifyMouseReleased(mousePt.x, mousePt.y, button);
 		instance->buttonPressed=false;
 	}
 	instance->buttonInUse = button;

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -698,13 +698,24 @@ int	ofxAppGLFWWindowMulti::getWindowMode(){
 }
 
 //------------------------------------------------------------
-void ofxAppGLFWWindowMulti::setWindowPosition(int x, int y){
-    glfwSetWindowPos(windows[currentWindow]->windowPtr,x,y);
-    
-    if( windows[currentWindow]->bFullscreen == false ){
-        windows[currentWindow]->windowBounds.x = x;
-        windows[currentWindow]->windowBounds.y = y;
+void ofxAppGLFWWindowMulti::setWindowPosition(int windowNo, int x, int y){
+    if (!ofInRange(windowNo, 0, windows.size())) {
+        ofLogError("ofxAppGLFWWindowMulti") << "setWindowPosition()"
+            << "window doesn't exist with windowNo: " << windowNo;
+        return;
     }
+
+    glfwSetWindowPos(windows[windowNo]->windowPtr,x,y);
+    
+    if( windows[windowNo]->bFullscreen == false ){
+        windows[windowNo]->windowBounds.x = x;
+        windows[windowNo]->windowBounds.y = y;
+    }
+}
+
+//------------------------------------------------------------
+void ofxAppGLFWWindowMulti::setWindowPosition(int x, int y){
+    setWindowPosition(currentWindow, x, x);
 }
 
 //------------------------------------------------------------

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -638,11 +638,7 @@ ofPoint ofxAppGLFWWindowMulti::getScreenSize(int windowNo){
                     return ofVec3f(desktopMode->width, desktopMode->height,0);
                 }
             }
-        }else{
-            return ofPoint(0,0);
         }
-    }else{
-        return ofPoint(0,0);
     }
 
     ofLogError("ofxAppGLFWWindowMulti") << "getScreenSize(): "

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -615,7 +615,7 @@ ofPoint ofxAppGLFWWindowMulti::getScreenSize(){
 }
 
 //------------------------------------------------------------
-int ofxAppGLFWWindowMulti::getWidth(){
+int ofxAppGLFWWindowMulti::getWidth(int winNo){
     if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
         return getWindowSize().x;
     }else{
@@ -624,13 +624,22 @@ int ofxAppGLFWWindowMulti::getWidth(){
 }
 
 //------------------------------------------------------------
-int ofxAppGLFWWindowMulti::getHeight()
-{
+int ofxAppGLFWWindowMulti::getWidth(){
+    return getWidth(currentWindow);
+}
+
+//------------------------------------------------------------
+int ofxAppGLFWWindowMulti::getHeight(int winNo){
     if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
         return getWindowSize().y;
     }else{
         return getWindowSize().x;
     }
+}
+
+//------------------------------------------------------------
+int ofxAppGLFWWindowMulti::getHeight(){
+    return getHeight(currentWindow);
 }
 
 //------------------------------------------------------------

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -337,7 +337,7 @@ void ofxAppGLFWWindowMulti::setupOpenGL(int w, int h, int screenMode){
         }
         
         //update our window info
-        getWindowSize();
+        updateWindowSize(i);
         getWindowPosition();
     }
     
@@ -520,19 +520,29 @@ void ofxAppGLFWWindowMulti::setWindowTitle(string title){
 }
 
 //------------------------------------------------------------
-ofPoint ofxAppGLFWWindowMulti::getWindowSize(){
-    int windowW, windowH; 
-    glfwGetWindowSize(windows[currentWindow]->windowPtr,&windowW,&windowH);
-    
-    if( windows[currentWindow]->bFullscreen == false ){
-        windows[currentWindow]->windowBounds.width  = windowW;
-        windows[currentWindow]->windowBounds.height = windowH;
+ofPoint ofxAppGLFWWindowMulti::updateWindowSize(int winNo) {
+    int windowW, windowH;
+    glfwGetWindowSize(windows[winNo]->windowPtr,&windowW,&windowH);
+
+    if( windows[winNo]->bFullscreen == false ){
+        windows[winNo]->windowBounds.width  = windowW;
+        windows[winNo]->windowBounds.height = windowH;
     }else{
-        windows[currentWindow]->fullScreenBounds.width  = windowW;
-        windows[currentWindow]->fullScreenBounds.height = windowH;
+        windows[winNo]->fullScreenBounds.width  = windowW;
+        windows[winNo]->fullScreenBounds.height = windowH;
     }
-    
-    return ofPoint(windowW,windowH);
+
+    return ofPoint(windowW, windowH);
+}
+
+//------------------------------------------------------------
+ofPoint ofxAppGLFWWindowMulti::getWindowSize(){
+    return updateWindowSize(currentWindow);
+}
+
+//------------------------------------------------------------
+ofPoint ofxAppGLFWWindowMulti::getWindowSize(int winNo){
+    return updateWindowSize(winNo);
 }
 
 //------------------------------------------------------------
@@ -775,7 +785,10 @@ void ofxAppGLFWWindowMulti::setFullscreen(bool fullscreen){
     int currentMonitor = getCurrentMonitor();
 
 	if( windows[currentWindow]->bFullscreen ){
-        windows[currentWindow]->windowBounds.set(getWindowPosition().x, getWindowPosition().y, getWindowSize().x, getWindowSize().y);
+        windows[currentWindow]->windowBounds.set(getWindowPosition().x,
+                                                 getWindowPosition().y,
+                                                 getWindowSize(currentWindow).x,
+                                                 getWindowSize(currentWindow).y);
  
 		//----------------------------------------------------
         if( currentMonitor == 0 ){
@@ -846,7 +859,10 @@ void ofxAppGLFWWindowMulti::setFullscreen(bool fullscreen){
 	}
 #elif defined(TARGET_WIN32)
     if( windows[currentWindow]->bFullscreen){
-        windows[currentWindow]->windowBounds.set(getWindowPosition().x, getWindowPosition().y, getWindowSize().x, getWindowSize().y);
+        windows[currentWindow]->windowBounds.set(getWindowPosition().x,
+                                                 getWindowPosition().y,
+                                                 getWindowSize(currentWindow).x,
+                                                 getWindowSize(currentWindow).y);
  
 		//----------------------------------------------------
 		HWND hwnd = glfwGetWin32Window(windows[currentWindow]->windowPtr);
@@ -1212,7 +1228,7 @@ void ofxAppGLFWWindowMulti::keyboard_cb(GLFWwindow* windowP_, int keycode, int s
 void ofxAppGLFWWindowMulti::resize_cb(GLFWwindow* windowP_,int w, int h) {
     instance->setFocusedWindow(windowP_);
 
-	instance->getWindowSize();
+    instance->updateWindowSize(instance->getFocusedWindowNo());
     
     //only do resize notification for main window
     //TODO: should this be so? resize useful for other windows

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -546,19 +546,24 @@ ofPoint ofxAppGLFWWindowMulti::getWindowSize(int winNo){
 }
 
 //------------------------------------------------------------
-ofPoint ofxAppGLFWWindowMulti::getWindowPosition(){
-    int x, y; 
-	glfwGetWindowPos(windows[currentWindow]->windowPtr, &x, &y);
-    
-    if( windows[currentWindow]->bFullscreen == false ){
-        windows[currentWindow]->windowBounds.x = x;
-        windows[currentWindow]->windowBounds.y = y;
+ofPoint ofxAppGLFWWindowMulti::getWindowPosition(int winNo){
+    int x, y;
+    glfwGetWindowPos(windows[winNo]->windowPtr, &x, &y);
+
+    if( windows[winNo]->bFullscreen == false ){
+        windows[winNo]->windowBounds.x = x;
+        windows[winNo]->windowBounds.y = y;
     }else{
-        windows[currentWindow]->fullScreenBounds.x = x;
-        windows[currentWindow]->fullScreenBounds.y = y;
+        windows[winNo]->fullScreenBounds.x = x;
+        windows[winNo]->fullScreenBounds.y = y;
     }
-    
+
     return ofPoint(x,y,0);
+}
+
+//------------------------------------------------------------
+ofPoint ofxAppGLFWWindowMulti::getWindowPosition(){
+    return getWindowPosition(currentWindow);
 }
 
 //------------------------------------------------------------

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -567,20 +567,19 @@ ofPoint ofxAppGLFWWindowMulti::getWindowPosition(){
 }
 
 //------------------------------------------------------------
+int ofxAppGLFWWindowMulti::getWindowMonitor(int winNo){
+    int numberOfMonitors;
+    GLFWmonitor** monitors = glfwGetMonitors(&numberOfMonitors);
 
-int ofxAppGLFWWindowMulti::getCurrentMonitor(){
-	int numberOfMonitors;
-	GLFWmonitor** monitors = glfwGetMonitors(&numberOfMonitors);
+    int xW;	int yW;
+    glfwGetWindowPos(windows[winNo]->windowPtr, &xW, &yW);
 
-	int xW;	int yW;
-	glfwGetWindowPos(windows[currentWindow]->windowPtr, &xW, &yW);
-    
-	for (int iC=0; iC < numberOfMonitors; iC++){
-		int xM; int yM;
-		glfwGetMonitorPos(monitors[iC], &xM, &yM);
-		const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[iC]);
-		ofRectangle monitorRect(xM, yM, desktopMode->width, desktopMode->height);
-        
+    for (int iC=0; iC < numberOfMonitors; iC++){
+        int xM; int yM;
+        glfwGetMonitorPos(monitors[iC], &xM, &yM);
+        const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[iC]);
+        ofRectangle monitorRect(xM, yM, desktopMode->width, desktopMode->height);
+
         //we have to do this so the inside returns true for a window going fullscreen on that monitor
         if( xW == xM ){
             xW += 1;
@@ -588,13 +587,18 @@ int ofxAppGLFWWindowMulti::getCurrentMonitor(){
         if( yW == yM ){
             yW += 1;
         }
-        
-		if (monitorRect.inside(xW, yW)){
-			return iC;
-			break;
-		}
-	}
-	return 0;
+
+        if (monitorRect.inside(xW, yW)){
+            return iC;
+            break;
+        }
+    }
+    return 0;
+}
+
+//------------------------------------------------------------
+int ofxAppGLFWWindowMulti::getCurrentMonitor(){
+    return getWindowMonitor(currentWindow);
 }
 
 //------------------------------------------------------------
@@ -602,8 +606,8 @@ ofPoint ofxAppGLFWWindowMulti::getScreenSize(int winNo){
     int count;
     GLFWmonitor** monitors = glfwGetMonitors(&count);
     if(count>0){
-        int currentMonitor = getCurrentMonitor();
-        const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[winNo]);
+        int winMonitor = getWindowMonitor(winNo);
+        const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[winMonitor]);
         if(desktopMode){
             if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
                 return ofVec3f(desktopMode->width, desktopMode->height,0);

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -177,6 +177,16 @@ bool ofxAppGLFWWindowMulti::closeWindow(int windowNo){
         if( windows[windowNo]->windowPtr != NULL ){
             glfwDestroyWindow(windows[windowNo]->windowPtr);
             windows[windowNo]->windowPtr = NULL;
+
+            if (windowNo == focusedWindow) {
+                focusedWindow = 0;
+                // TODO This is ok as long as closing window 0 ends the app,
+                // if it's possible to close window 0, and still have other
+                // windows open, this is problematic
+            }
+            if (windowNo == 0) {
+                OF_EXIT_APP(0);
+            }
         }
         
     } else {

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -887,9 +887,8 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
                                             winSize.x, winSize.y);
  
 		//----------------------------------------------------
-        if( windowNo == 0 ){
-            SetSystemUIMode(kUIModeAllHidden,NULL);
-        }
+        SetSystemUIMode(kUIModeAllHidden,NULL);
+
 		NSWindow * cocoaWindow = glfwGetCocoaWindow(windows[windowNo]->windowPtr);
  
 		[cocoaWindow setStyleMask:NSBorderlessWindowMask];

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -941,9 +941,7 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
         [cocoaWindow makeFirstResponder:cocoaWindow.contentView];
  
 	}else if( windows[windowNo]->bFullscreen == false  ){
-        if( windowMonitor == 0 ){
-            SetSystemUIMode(kUIModeNormal,NULL);
-        }
+        SetSystemUIMode(kUIModeNormal,NULL);
         
 		NSWindow * cocoaWindow = glfwGetCocoaWindow(windows[windowNo]->windowPtr);
 		[cocoaWindow setStyleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask];

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -709,11 +709,11 @@ int ofxAppGLFWWindowMulti::getWindowMode(int windowNo){
     ofLogError("ofxAppGLFWWindowMulti::getWindowMode")
         << "window doesn't exist with windowNo: " << windowNo;
 
-    return -1;
+    return OF_WINDOW;
 }
 
 //------------------------------------------------------------
-int	ofxAppGLFWWindowMulti::getWindowMode(){
+int ofxAppGLFWWindowMulti::getWindowMode(){
     return getWindowMode(currentWindow);
 }
 

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -730,10 +730,20 @@ void ofxAppGLFWWindowMulti::setWindowPosition(int x, int y){
 }
 
 //------------------------------------------------------------
-void ofxAppGLFWWindowMulti::setWindowShape(int w, int h){
-	glfwSetWindowSize(windows[currentWindow]->windowPtr,w,h);
+void ofxAppGLFWWindowMulti::setWindowShape(int windowNo, int w, int h){
+    if (!ofInRange(windowNo, 0, windows.size())) {
+        ofLogError("ofxAppGLFWWindowMulti") << "setWindowShape()"
+            << "window doesn't exist with windowNo: " << windowNo;
+        return;
+    }
+
+	glfwSetWindowSize(windows[windowNo]->windowPtr,w,h);
 }
 
+//------------------------------------------------------------
+void ofxAppGLFWWindowMulti::setWindowShape(int w, int h){
+    setWindowShape(currentWindow, w, h);
+}
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::hideCursor(){
 	glfwSetInputMode(windows[currentWindow]->windowPtr,GLFW_CURSOR,GLFW_CURSOR_HIDDEN);

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -517,9 +517,20 @@ void ofxAppGLFWWindowMulti::display(GLFWwindow* window){
 }
 
 //------------------------------------------------------------
+void ofxAppGLFWWindowMulti::setWindowTitle(int windowNo, string title){
+    if (!ofInRange(windowNo, 0, windows.size())) {
+        ofLogError("ofxAppGLFWWindowMulti") << "setWindowTitle()"
+            << "window doesn't exist with windowNo: " << windowNo;
+        return;
+    }
+
+    windows[windowNo]->windowName = title;
+	glfwSetWindowTitle(windows[windowNo]->windowPtr,title.c_str());
+}
+
+//------------------------------------------------------------
 void ofxAppGLFWWindowMulti::setWindowTitle(string title){
-    windows[currentWindow]->windowName = title;
-	glfwSetWindowTitle(windows[currentWindow]->windowPtr,title.c_str());
+    setWindowTitle(currentWindow, title);
 }
 
 //------------------------------------------------------------

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -1169,22 +1169,10 @@ void ofxAppGLFWWindowMulti::motion_cb(GLFWwindow* windowP_, double x, double y) 
 
     instance->windows[instance->focusedWindow]->mousePt.set(x, y);
 
-    if( instance->focusedWindow == 0 ){
-
-        if(!instance->buttonPressed){
-            ofNotifyMouseMoved(x, y);
-        }else{
-            ofNotifyMouseDragged(x, y, instance->buttonInUse);
-        }
-
+    if(!instance->buttonPressed){
+        ofNotifyMouseMoved(x, y);
     }else{
-
-        if(!instance->buttonPressed){
-            ofAppPtr->mouseMoved(x, y);
-        }else{
-            ofAppPtr->mouseDragged(x, y, instance->buttonInUse);
-        }
-
+        ofNotifyMouseDragged(x, y, instance->buttonInUse);
     }
 }
 

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -1340,15 +1340,8 @@ void ofxAppGLFWWindowMulti::keyboard_cb(GLFWwindow* windowP_, int keycode, int s
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::resize_cb(GLFWwindow* windowP_,int w, int h) {
     instance->setFocusedWindow(windowP_);
-
     instance->updateWindowSize(instance->getFocusedWindowNo());
-    
-    //only do resize notification for main window
-    //TODO: should this be so? resize useful for other windows
-    if(windowP_ == instance->windows[0]->windowPtr){
-        ofNotifyWindowResized(w, h);
-    }
-    
+    ofNotifyWindowResized(w, h);
 	instance->nFramesSinceWindowResized = 0;
 }
 

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -241,7 +241,6 @@ bool ofxAppGLFWWindowMulti::pushWindow(int newWindow){
         if( windows[newWindow]->windowPtr != NULL ){
             windowStack.push_back(currentWindow);
             currentWindow = newWindow;
-            focusedWindow = newWindow;
             return true;
         }
     }
@@ -256,7 +255,6 @@ void ofxAppGLFWWindowMulti::popWindow(){
         if( newWindow >= 0 && newWindow < windows.size() ){
             if( windows[newWindow]->windowPtr != NULL ){
                 currentWindow = newWindow;
-                focusedWindow = newWindow;
             }else{
                 currentWindow = 0;
             }

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -592,26 +592,30 @@ int ofxAppGLFWWindowMulti::getCurrentMonitor(){
 	return 0;
 }
 
+//------------------------------------------------------------
+ofPoint ofxAppGLFWWindowMulti::getScreenSize(int winNo){
+    int count;
+    GLFWmonitor** monitors = glfwGetMonitors(&count);
+    if(count>0){
+        int currentMonitor = getCurrentMonitor();
+        const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[winNo]);
+        if(desktopMode){
+            if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
+                return ofVec3f(desktopMode->width, desktopMode->height,0);
+            }else{
+                return ofPoint(0,0);
+            }
+        }else{
+            return ofPoint(0,0);
+        }
+    }else{
+        return ofPoint(0,0);
+    }
+}
 
 //------------------------------------------------------------
 ofPoint ofxAppGLFWWindowMulti::getScreenSize(){
-	int count;
-	GLFWmonitor** monitors = glfwGetMonitors(&count);
-	if(count>0){
-		int currentMonitor = getCurrentMonitor();
-		const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[currentMonitor]);
-		if(desktopMode){
-			if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
-				return ofVec3f(desktopMode->width, desktopMode->height,0);
-			}else{
-				return ofPoint(0,0);
-			}
-		}else{
-			return ofPoint(0,0);
-		}
-	}else{
-		return ofPoint(0,0);
-	}
+    return getScreenSize(currentWindow);
 }
 
 //------------------------------------------------------------

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -69,11 +69,11 @@ ofxAppGLFWWindowMulti::ofxAppGLFWWindowMulti():ofAppBaseWindow(){
 
 	glVersionMinor=glVersionMajor=-1;
 	nFramesSinceWindowResized = 0;
-    
+
     addWindow("main window", 0, 0, 1024, 768);
 
     currentWindow = 0;
-    
+
     focusedWindow = 0;
 
     //default to 4 times antialiasing.
@@ -90,7 +90,7 @@ void ofxAppGLFWWindowMulti::setNumSamples(int _samples){
 
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::setMultiDisplayFullscreen(bool bMultiFullscreen){
-    bMultiWindowFullscreen = bMultiFullscreen; 
+    bMultiWindowFullscreen = bMultiFullscreen;
 }
 
 //------------------------------------------------------------
@@ -129,40 +129,40 @@ void ofxAppGLFWWindowMulti::setOpenGLVersion(int major, int minor){
 
 //------------------------------------------------------------
 int ofxAppGLFWWindowMulti::addWindow(string windowName, float x, float y, float w, float h, bool bFullscreen){
-    
+
         shared_ptr <AppGLFWSingleWindow> winPtr( new AppGLFWSingleWindow() );
         winPtr->windowNo = windows.size();
         winPtr->windowName = windowName;
-    
+
         if( windows.size() >= 1 ){
-        
+
             if( isSetup ){
                 winPtr->windowPtr = glfwCreateWindow(w, h, windowName.c_str(), NULL, windows[0]->windowPtr);
-                
-                
-                
+
+
+
                 if( pushWindow(winPtr->windowNo) ){
-                    
+
                     setWindowTitle(windowName);
                     setWindowShape(w, h);
                     setWindowPosition(x, y);
                     setFullscreen(bFullscreen);
-                    
+
                     popWindow();
                 }
-                
+
             }else{
                 winPtr->windowName = windowName;
                 winPtr->windowBounds.set(x, y, w, h);
                 winPtr->bFullscreen = bFullscreen;
             }
-            
+
         }else{
             winPtr->bMainWindow = true;
         }
-    
+
         windows.push_back( winPtr );
-    
+
         if( isSetup ){
             initializeWindow();
         }
@@ -200,12 +200,12 @@ bool ofxAppGLFWWindowMulti::closeWindow(int windowNo){
 
 //------------------------------------------------------------
 int ofxAppGLFWWindowMulti::getNumWindows(){
-    return windows.size(); 
+    return windows.size();
 }
 
 //------------------------------------------------------------
 int ofxAppGLFWWindowMulti::getNumActiveWindows() {
-    
+
     int totalWins = 0;
     for(int i = 0; i < windows.size(); i++) {
         if( windows[i]->windowPtr != NULL ) {
@@ -232,7 +232,7 @@ bool ofxAppGLFWWindowMulti::isWindowInFocus(int windowNo){
 
 //------------------------------------------------------------
 vector <shared_ptr <AppGLFWSingleWindow> > ofxAppGLFWWindowMulti::getWindows(){
-    return windows; 
+    return windows;
 }
 
 //------------------------------------------------------------
@@ -251,7 +251,7 @@ bool ofxAppGLFWWindowMulti::pushWindow(int newWindow){
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::popWindow(){
     if( windowStack.size() ){
-        
+
         int newWindow = windowStack.back();
         if( newWindow >= 0 && newWindow < windows.size() ){
             if( windows[newWindow]->windowPtr != NULL ){
@@ -277,11 +277,11 @@ void ofxAppGLFWWindowMulti::setupOpenGL(int w, int h, int screenMode){
         ofLogError("ofxAppGLFWWindowMulti") << "can't do game mode";
         return;
 	}
-    
+
     windows[0]->bFullscreen = (screenMode == OF_FULLSCREEN);
-    
+
 //	ofLogNotice("ofxAppGLFWWindowMulti") << "WINDOW MODE IS " << screenMode;
-    
+
 	glfwWindowHint(GLFW_RED_BITS, rBits);
 	glfwWindowHint(GLFW_GREEN_BITS, gBits);
 	glfwWindowHint(GLFW_BLUE_BITS, bBits);
@@ -306,19 +306,19 @@ void ofxAppGLFWWindowMulti::setupOpenGL(int w, int h, int screenMode){
 		glfwWindowHint(GLFW_CLIENT_API,GLFW_OPENGL_ES_API);
 		#endif
 	}
-    
+
 	setVerticalSync(false);
-    
+
     for(int i = 0; i < windows.size(); i++){
         if( windows[i]->windowPtr == NULL ){
             if( i == 0 ){
                 windows[i]->windowPtr = glfwCreateWindow(w, h, "", NULL, NULL);
-                
+
                 if(!windows[0]->windowPtr){
                     ofLogError("ofxAppGLFWWindowMulti") << "couldn't create GLFW window";
                     return;
                 }
-                
+
                 windows[i]->windowBounds.setWidth(w);
                 windows[i]->windowBounds.setHeight(h);
 
@@ -327,17 +327,17 @@ void ofxAppGLFWWindowMulti::setupOpenGL(int w, int h, int screenMode){
             }
         }
     }
-    
-    
+
+
     for(int i = 0; i < windows.size(); i++){
 
         glfwMakeContextCurrent(windows[i]->windowPtr);
-        
-        if( pushWindow(windows[i]->windowNo) ){        
+
+        if( pushWindow(windows[i]->windowNo) ){
             if( windows[i]->bFullscreen ){
                 //so that setFullscreen doesn't think its been set already
                 windows[i]->bFullscreen = false;
-                
+
                 //need to move to the right window first
                 setWindowPosition(windows[i]->windowBounds.x, windows[i]->windowBounds.y);
                 setFullscreen(true);
@@ -349,14 +349,14 @@ void ofxAppGLFWWindowMulti::setupOpenGL(int w, int h, int screenMode){
 
             popWindow();
         }
-        
+
         //update our window info
         updateWindowSize(i);
         getWindowPosition();
     }
-    
+
     glfwMakeContextCurrent(windows[0]->windowPtr);
-    
+
     isSetup = true;
     ofGLReadyCallback();
 }
@@ -385,16 +385,16 @@ void ofxAppGLFWWindowMulti::initializeWindow(){
     for(int i = 0; i < windows.size(); i++){
         if( windows[i]->bInitialized ||windows[i]->windowPtr == NULL)continue;
         windows[i]->bInitialized = true;
-        
+
         if( i == 0 ){
             glfwSetWindowCloseCallback(windows[i]->windowPtr, exit_cb);
         }else{
             glfwSetWindowCloseCallback(windows[i]->windowPtr, close_cb);
         }
-        
+
         glfwSetMouseButtonCallback(windows[i]->windowPtr, mouse_cb);
         glfwSetCursorPosCallback(windows[i]->windowPtr, motion_cb);
-        
+
         glfwSetKeyCallback(windows[i]->windowPtr, keyboard_cb);
         glfwSetWindowSizeCallback(windows[i]->windowPtr, resize_cb);
         glfwSetScrollCallback(windows[i]->windowPtr, scroll_cb);
@@ -441,9 +441,9 @@ void ofxAppGLFWWindowMulti::runAppViaInfiniteLoop(ofBaseApp * appPtr){
         for(int i = 0; i < windows.size(); i++){
             //skip closed windows
             if( windows[i]->windowPtr == NULL ) continue;
-            
+
             glfwMakeContextCurrent(windows[i]->windowPtr);
-            
+
             currentWindow = i;
             if( currentWindow == 0 ){
                 ofNotifyUpdate();
@@ -479,14 +479,14 @@ void ofxAppGLFWWindowMulti::display(GLFWwindow* window){
 	}
 
 	if( bEnableSetupScreen )ofSetupScreen();
-    
+
     //we do this because the framecounter is otherwise incremented twice;
     if(currentWindow == 0){
         ofNotifyDraw();
     }else{
         ofAppPtr->draw();
     }
-    
+
 
 	#ifdef TARGET_WIN32
 	if (bClearAuto == false){
@@ -786,16 +786,16 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
     }
 
     windows[windowNo]->bFullscreen = fullscreen;
- 
+
 
 #ifdef TARGET_LINUX
 #include <X11/Xatom.h>
- 
+
     Window nativeWin = glfwGetX11Window(windows[windowNo]->windowPtr);
 	Display* display = glfwGetX11Display();
 	int monitorCount;
 	GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
- 
+
 	if( bMultiWindowFullscreen && monitorCount > 1 ){
 		// find the monitors at the edges of the virtual desktop
 		int minx=numeric_limits<int>::max();
@@ -823,21 +823,21 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
             	monitorBottom = i;
             	maxy = y+h;
             }
- 
+
         }
- 
+
         // send fullscreen_monitors event with the edges monitors
 		Atom m_net_fullscreen_monitors= XInternAtom(display, "_NET_WM_FULLSCREEN_MONITORS", false);
- 
+
 		XEvent xev;
- 
+
 		xev.xclient.type = ClientMessage;
 		xev.xclient.serial = 0;
 		xev.xclient.send_event = True;
 		xev.xclient.window = nativeWin;
 		xev.xclient.message_type = m_net_fullscreen_monitors;
 		xev.xclient.format = 32;
- 
+
 		xev.xclient.data.l[0] = monitorTop;
 		xev.xclient.data.l[1] = monitorBottom;
 		xev.xclient.data.l[2] = monitorLeft;
@@ -845,44 +845,44 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
 		xev.xclient.data.l[4] = 1;
 		XSendEvent(display, RootWindow(display, DefaultScreen(display)),
 				   False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
- 
+
 	}
- 
+
 	// send fullscreen event
 	Atom m_net_state= XInternAtom(display, "_NET_WM_STATE", false);
 	Atom m_net_fullscreen= XInternAtom(display, "_NET_WM_STATE_FULLSCREEN", false);
- 
+
 	XEvent xev;
- 
+
 	xev.xclient.type = ClientMessage;
 	xev.xclient.serial = 0;
 	xev.xclient.send_event = True;
 	xev.xclient.window = nativeWin;
 	xev.xclient.message_type = m_net_state;
 	xev.xclient.format = 32;
- 
+
 	if (fullscreen)
 		xev.xclient.data.l[0] = 1;
 	else
 		xev.xclient.data.l[0] = 0;
- 
+
 	xev.xclient.data.l[1] = m_net_fullscreen;
 	xev.xclient.data.l[2] = 0;
 	xev.xclient.data.l[3] = 0;
 	xev.xclient.data.l[4] = 0;
 	XSendEvent(display, RootWindow(display, DefaultScreen(display)),
 			   False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
- 
+
 	// tell the window manager to bypass composition for this window in fullscreen for speed
 	// it'll probably help solving vsync issues
 	Atom m_bypass_compositor = XInternAtom(display, "_NET_WM_BYPASS_COMPOSITOR", False);
 	unsigned long value = fullscreen ? 1 : 0;
 	XChangeProperty(display, nativeWin, m_bypass_compositor, XA_CARDINAL, 32, PropModeReplace, (unsigned char*)&value, 1);
- 
+
 	XFlush(display);
- 
+
 #elif defined(TARGET_OSX)
-	
+
     int monitorCount;
     GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
     int windowMonitor = getWindowMonitor(windowNo);
@@ -893,19 +893,19 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
 
         windows[windowNo]->windowBounds.set(winPos.x, winPos.y,
                                             winSize.x, winSize.y);
- 
+
 		//----------------------------------------------------
         SetSystemUIMode(kUIModeAllHidden,NULL);
 
 		NSWindow * cocoaWindow = glfwGetCocoaWindow(windows[windowNo]->windowPtr);
- 
+
 		[cocoaWindow setStyleMask:NSBorderlessWindowMask];
- 
+
 		ofPoint screenSize = getScreenSize(windowNo);
 		ofRectangle allScreensSpace;
- 
+
         if( bMultiWindowFullscreen && monitorCount > 1 ){
- 
+
 			//calc the sum Rect of all the monitors
 			for(int i = 0; i < monitorCount; i++){
 				const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[i]);
@@ -917,12 +917,12 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
 			//for OS X we need to set this first as the window size affects the window positon
 			setWindowShape(windowNo, allScreensSpace.width, allScreensSpace.height);
 			setWindowPosition(windowNo, allScreensSpace.x, allScreensSpace.y);
- 
+
         }else if (monitorCount > 1 && windowMonitor < monitorCount){
             int xpos;
 			int ypos;
 			glfwGetMonitorPos(monitors[windowMonitor], &xpos, &ypos);
- 
+
             //we do this as setWindowShape affects the position of the monitor
             //normally we would just call setWindowShape first, but on multi monitor you see the window bleed onto the second monitor as it first changes shape and is then repositioned.
             //this first moves it over in X, does the screen resize and then by calling it again its set correctly in y.
@@ -934,20 +934,20 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
             setWindowShape(windowNo, screenSize.x, screenSize.y);
 			setWindowPosition(windowNo, 0,0);
 		}
- 
+
         //make sure the window is getting the mouse/key events
         [cocoaWindow makeFirstResponder:cocoaWindow.contentView];
- 
+
 	}else if( windows[windowNo]->bFullscreen == false  ){
         SetSystemUIMode(kUIModeNormal,NULL);
-        
+
 		NSWindow * cocoaWindow = glfwGetCocoaWindow(windows[windowNo]->windowPtr);
 		[cocoaWindow setStyleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask];
- 
+
 		setWindowShape(windowNo,
                        windows[windowNo]->windowBounds.getWidth(),
                        windows[windowNo]->windowBounds.getHeight());
- 
+
 		//----------------------------------------------------
 		// if we have recorded the screen position, put it there
 		// if not, better to let the system do it (and put it where it wants)
@@ -955,7 +955,7 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
 			setWindowPosition(windows[windowNo]->windowBounds.x,
                               windows[windowNo]->windowBounds.y);
 		}
- 
+
 		//----------------------------------------------------
         //make sure the window is getting the mouse/key events
         [cocoaWindow makeFirstResponder:cocoaWindow.contentView];
@@ -970,24 +970,24 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
 
 		//----------------------------------------------------
 		HWND hwnd = glfwGetWin32Window(windows[windowNo]->windowPtr);
- 
+
 		SetWindowLong(hwnd, GWL_EXSTYLE, 0);
   		SetWindowLong(hwnd, GWL_STYLE, WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS);
   		SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
- 
+
         float fullscreenW = getScreenSize(windowNo).x;
         float fullscreenH = getScreenSize(windowNo).y;
- 
+
         int xpos = 0;
         int ypos = 0;
- 
+
         if( bMultiWindowFullscreen ){
- 
+
             float totalWidth = 0.0;
             float maxHeight  = 0.0;
             int monitorCount;
             GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
- 
+
             //lets find the total width of all the monitors
             //and we'll make the window height the height of the largest monitor.
             for(int i = 0; i < monitorCount; i++){
@@ -997,32 +997,32 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
                     maxHeight = desktopMode->height;
                 }
             }
- 
+
             fullscreenW = totalWidth;
             fullscreenH = maxHeight;
         }else{
- 
+
             int monitorCount;
             GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
             int windowMonitor = getWindowMonitor(windowNo);
             glfwGetMonitorPos(monitors[windowMonitor], &xpos, &ypos);
- 
+
         }
- 
+
         SetWindowPos(hwnd, HWND_TOPMOST, xpos, ypos, fullscreenW, fullscreenH, SWP_SHOWWINDOW);
- 
+
 	}else if( windows[windowNo]->bFullscreen == false ){
- 
+
 		HWND hwnd = glfwGetWin32Window(windows[windowNo]->windowPtr);
- 
+
   		DWORD EX_STYLE = WS_EX_OVERLAPPEDWINDOW;
 		DWORD STYLE = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
- 
+
 	  	ChangeDisplaySettings(0, 0);
 		SetWindowLong(hwnd, GWL_EXSTYLE, EX_STYLE);
 		SetWindowLong(hwnd, GWL_STYLE, STYLE);
   		SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
- 
+
 		//not sure why this is - but if we don't do this the window shrinks by 4 pixels in x and y
 		//should look for a better fix.
 		setWindowPosition(windows[windowNo]->windowBounds.x-2,
@@ -1115,12 +1115,12 @@ void ofxAppGLFWWindowMulti::mouse_cb(GLFWwindow* windowP_, int button, int state
 	ofLogVerbose("ofxAppGLFWWindowMulti") << "mouse button: " << button;
 
 #ifdef TARGET_OSX
-    //we do this as unlike glut, glfw doesn't report right click for ctrl click or middle click for alt click 
+    //we do this as unlike glut, glfw doesn't report right click for ctrl click or middle click for alt click
     if( ofGetKeyPressed(OF_KEY_CONTROL) && button == GLFW_MOUSE_BUTTON_LEFT){
-        button = GLFW_MOUSE_BUTTON_RIGHT; 
+        button = GLFW_MOUSE_BUTTON_RIGHT;
     }
     if( ofGetKeyPressed(OF_KEY_ALT) && button == GLFW_MOUSE_BUTTON_LEFT){
-        button = GLFW_MOUSE_BUTTON_MIDDLE; 
+        button = GLFW_MOUSE_BUTTON_MIDDLE;
     }
 #endif
 
@@ -1178,7 +1178,7 @@ void ofxAppGLFWWindowMulti::motion_cb(GLFWwindow* windowP_, double x, double y) 
         }else{
             ofNotifyMouseDragged(x, y, instance->buttonInUse);
         }
-    
+
     }else{
 
         if(!instance->buttonPressed){
@@ -1186,7 +1186,7 @@ void ofxAppGLFWWindowMulti::motion_cb(GLFWwindow* windowP_, double x, double y) 
         }else{
             ofAppPtr->mouseDragged(x, y, instance->buttonInUse);
         }
-    
+
     }
 }
 
@@ -1224,7 +1224,7 @@ void ofxAppGLFWWindowMulti::setFocusedWindow(GLFWwindow * windowP_){
 
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::keyboard_cb(GLFWwindow* windowP_, int keycode, int scancode, unsigned int codepoint, int action, int mods) {
-    
+
         int key;
 
 
@@ -1331,10 +1331,10 @@ void ofxAppGLFWWindowMulti::keyboard_cb(GLFWwindow* windowP_, int keycode, int s
 			break;
 		case GLFW_KEY_KP_ENTER:
 			key = OF_KEY_RETURN;
-			break;   
+			break;
 		case GLFW_KEY_TAB:
 			key = OF_KEY_TAB;
-			break;   
+			break;
 		default:
 			key = codepoint;
 			break;

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -167,13 +167,13 @@ int ofxAppGLFWWindowMulti::addWindow(string windowName, float x, float y, float 
             initializeWindow();
         }
         setFocusedWindow(winPtr->windowPtr);
+
         return winPtr->windowNo;
 }
 
 //------------------------------------------------------------
 bool ofxAppGLFWWindowMulti::closeWindow(int windowNo){
-    if(windowNo >= 0 && windowNo < windows.size()){
-    
+    if(ofInRange(windowNo, 0, windows.size())){
         if( windows[windowNo]->windowPtr != NULL ){
             glfwDestroyWindow(windows[windowNo]->windowPtr);
             windows[windowNo]->windowPtr = NULL;
@@ -187,14 +187,15 @@ bool ofxAppGLFWWindowMulti::closeWindow(int windowNo){
             if (windowNo == 0) {
                 OF_EXIT_APP(0);
             }
+
+            return true;
         }
-        
     } else {
-        ofLogError("ofxAppGLFWWindowMulti") << "closeWindow(): "
+        ofLogError("ofxAppGLFWWindowMulti::closeWindow")
             << "window doesn't exist with windowNo: " << windowNo;
     }
 
-	return true;
+	return false;
 }
 
 //------------------------------------------------------------
@@ -528,14 +529,13 @@ void ofxAppGLFWWindowMulti::display(GLFWwindow* window){
 
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::setWindowTitle(int windowNo, string title){
-    if (!ofInRange(windowNo, 0, windows.size())) {
-        ofLogError("ofxAppGLFWWindowMulti") << "setWindowTitle()"
+    if (ofInRange(windowNo, 0, windows.size())) {
+        windows[windowNo]->windowName = title;
+        glfwSetWindowTitle(windows[windowNo]->windowPtr,title.c_str());
+    } else {
+        ofLogError("ofxAppGLFWWindowMulti::setWindowTitle")
             << "window doesn't exist with windowNo: " << windowNo;
-        return;
     }
-
-    windows[windowNo]->windowName = title;
-	glfwSetWindowTitle(windows[windowNo]->windowPtr,title.c_str());
 }
 
 //------------------------------------------------------------
@@ -545,7 +545,7 @@ void ofxAppGLFWWindowMulti::setWindowTitle(string title){
 
 //------------------------------------------------------------
 ofPoint ofxAppGLFWWindowMulti::updateWindowSize(int windowNo) {
-    if(windowNo >= 0 && windowNo < windows.size()){
+    if(ofInRange(windowNo, 0, windows.size())) {
         int windowW, windowH;
         glfwGetWindowSize(windows[windowNo]->windowPtr,&windowW,&windowH);
 
@@ -560,7 +560,7 @@ ofPoint ofxAppGLFWWindowMulti::updateWindowSize(int windowNo) {
         return ofPoint(windowW, windowH);
     }
 
-    ofLogError("ofxAppGLFWWindowMulti") << "updateWindowSize(): "
+    ofLogError("ofxAppGLFWWindowMulti::updateWindowSize")
         << "window doesn't exist with windowNo: " << windowNo;
 
     return ofPoint(0,0);
@@ -578,7 +578,7 @@ ofPoint ofxAppGLFWWindowMulti::getWindowSize(int windowNo){
 
 //------------------------------------------------------------
 ofPoint ofxAppGLFWWindowMulti::getWindowPosition(int windowNo){
-    if(windowNo >= 0 && windowNo < windows.size()){
+    if(ofInRange(windowNo, 0, windows.size())) {
         int x, y;
         glfwGetWindowPos(windows[windowNo]->windowPtr, &x, &y);
 
@@ -593,7 +593,7 @@ ofPoint ofxAppGLFWWindowMulti::getWindowPosition(int windowNo){
         return ofPoint(x,y,0);
     }
 
-    ofLogError("ofxAppGLFWWindowMulti") << "getWindowPosition(): "
+    ofLogError("ofxAppGLFWWindowMulti::getWindowPosition")
         << "window doesn't exist with windowNo: " << windowNo;
 
     return ofPoint(0,0,0);
@@ -606,7 +606,7 @@ ofPoint ofxAppGLFWWindowMulti::getWindowPosition(){
 
 //------------------------------------------------------------
 int ofxAppGLFWWindowMulti::getWindowMonitor(int windowNo){
-    if(windowNo >= 0 && windowNo < windows.size()){
+    if(ofInRange(windowNo, 0, windows.size())) {
         int numberOfMonitors;
         GLFWmonitor** monitors = glfwGetMonitors(&numberOfMonitors);
 
@@ -629,16 +629,15 @@ int ofxAppGLFWWindowMulti::getWindowMonitor(int windowNo){
 
             if (monitorRect.inside(xW, yW)){
                 return iC;
-                break;
             }
         }
-        return 0;
+
     }
 
-    ofLogError("ofxAppGLFWWindowMulti") << "getWindowMonitor(): "
+    ofLogError("ofxAppGLFWWindowMulti::getWindowMonitor")
         << "window doesn't exist with windowNo: " << windowNo;
 
-    return -1;
+    return 0;
 }
 
 //------------------------------------------------------------
@@ -648,7 +647,7 @@ int ofxAppGLFWWindowMulti::getCurrentMonitor(){
 
 //------------------------------------------------------------
 ofPoint ofxAppGLFWWindowMulti::getScreenSize(int windowNo){
-    if(windowNo >= 0 && windowNo < windows.size()){
+    if(ofInRange(windowNo, 0, windows.size())) {
         int count;
         GLFWmonitor** monitors = glfwGetMonitors(&count);
         if(count>0){
@@ -660,10 +659,10 @@ ofPoint ofxAppGLFWWindowMulti::getScreenSize(int windowNo){
                 }
             }
         }
+    } else {
+        ofLogError("ofxAppGLFWWindowMulti::getScreenSize")
+            << "window doesn't exist with windowNo: " << windowNo;
     }
-
-    ofLogError("ofxAppGLFWWindowMulti") << "getScreenSize(): "
-        << "window doesn't exist with windowNo: " << windowNo;
 
     return ofPoint(0,0);
 }
@@ -703,11 +702,11 @@ int ofxAppGLFWWindowMulti::getHeight(){
 
 //------------------------------------------------------------
 int ofxAppGLFWWindowMulti::getWindowMode(int windowNo){
-    if(windowNo >= 0 && windowNo < windows.size()){
+    if(ofInRange(windowNo, 0, windows.size())) {
         return ( windows[windowNo]->bFullscreen ? OF_FULLSCREEN : OF_WINDOW );
     }
 
-    ofLogError("ofxAppGLFWWindowMulti") << "getWindowMode(): "
+    ofLogError("ofxAppGLFWWindowMulti::getWindowMode")
         << "window doesn't exist with windowNo: " << windowNo;
 
     return -1;
@@ -720,18 +719,18 @@ int	ofxAppGLFWWindowMulti::getWindowMode(){
 
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::setWindowPosition(int windowNo, int x, int y){
-    if (!ofInRange(windowNo, 0, windows.size())) {
-        ofLogError("ofxAppGLFWWindowMulti") << "setWindowPosition()"
+    if (ofInRange(windowNo, 0, windows.size())) {
+        glfwSetWindowPos(windows[windowNo]->windowPtr,x,y);
+
+        if( windows[windowNo]->bFullscreen == false ){
+            windows[windowNo]->windowBounds.x = x;
+            windows[windowNo]->windowBounds.y = y;
+        }
+    } else {
+        ofLogError("ofxAppGLFWWindowMulti::setWindowPosition")
             << "window doesn't exist with windowNo: " << windowNo;
-        return;
     }
 
-    glfwSetWindowPos(windows[windowNo]->windowPtr,x,y);
-    
-    if( windows[windowNo]->bFullscreen == false ){
-        windows[windowNo]->windowBounds.x = x;
-        windows[windowNo]->windowBounds.y = y;
-    }
 }
 
 //------------------------------------------------------------
@@ -741,13 +740,12 @@ void ofxAppGLFWWindowMulti::setWindowPosition(int x, int y){
 
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::setWindowShape(int windowNo, int w, int h){
-    if (!ofInRange(windowNo, 0, windows.size())) {
-        ofLogError("ofxAppGLFWWindowMulti") << "setWindowShape()"
+    if (ofInRange(windowNo, 0, windows.size())) {
+        glfwSetWindowSize(windows[windowNo]->windowPtr,w,h);
+    } else {
+        ofLogError("ofxAppGLFWWindowMulti::setWindowShape")
             << "window doesn't exist with windowNo: " << windowNo;
-        return;
     }
-
-	glfwSetWindowSize(windows[windowNo]->windowPtr,w,h);
 }
 
 //------------------------------------------------------------
@@ -777,7 +775,7 @@ void ofxAppGLFWWindowMulti::disableSetupScreen(){
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
     if (!ofInRange(windowNo, 0, windows.size())) {
-        ofLogError("ofxAppGLFWWindowMulti") << "setFullScreen()"
+        ofLogError("ofxAppGLFWWindowMulti::setFullScreen")
             << "window doesn't exist with windowNo: " << windowNo;
         return;
     }
@@ -1046,17 +1044,16 @@ void ofxAppGLFWWindowMulti::setFullscreen(bool fullscreen) {
 
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::toggleFullscreen(int windowNo){
-    if (!ofInRange(windowNo, 0, windows.size())) {
+    if (ofInRange(windowNo, 0, windows.size())) {
+        if(windows[windowNo]->bFullscreen == false){
+            setFullscreen(windowNo, true);
+        } else {
+            setFullscreen(windowNo, false);
+        }
+    } else {
         ofLogError("ofxAppGLFWWindowMulti::setFullScreen")
             << "window doesn't exist with windowNo: " << windowNo;
-        return;
     }
-
-	if(windows[windowNo]->bFullscreen == false){
-		setFullscreen(windowNo, true);
-	} else {
-		setFullscreen(windowNo, false);
-	}
 }
 
 //------------------------------------------------------------

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -655,7 +655,7 @@ ofPoint ofxAppGLFWWindowMulti::getScreenSize(int windowNo){
             const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[winMonitor]);
             if(desktopMode){
                 if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
-                    return ofVec3f(desktopMode->width, desktopMode->height,0);
+                    return ofPoint(desktopMode->width, desktopMode->height);
                 }
             }
         }
@@ -901,7 +901,7 @@ void ofxAppGLFWWindowMulti::setFullscreen(int windowNo, bool fullscreen){
  
 		[cocoaWindow setStyleMask:NSBorderlessWindowMask];
  
-		ofVec3f screenSize = getScreenSize(windowNo);
+		ofPoint screenSize = getScreenSize(windowNo);
 		ofRectangle allScreensSpace;
  
         if( bMultiWindowFullscreen && monitorCount > 1 ){

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -1163,7 +1163,12 @@ void ofxAppGLFWWindowMulti::mouse_cb(GLFWwindow* windowP_, int button, int state
 
 //------------------------------------------------------------
 void ofxAppGLFWWindowMulti::motion_cb(GLFWwindow* windowP_, double x, double y) {
-    instance->setFocusedWindow(windowP_);
+    // TODO in theory this shouldn't be necessary, but when a new window is
+    // created programatically (including via loading settings) callbacks are
+    // fired for multiple windows until window 0 is selected
+    if (!glfwGetWindowAttrib(windowP_, GLFW_FOCUSED)){
+        return;
+    }
 
 	rotateMouseXY(ofGetOrientation(), x, y);
 

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -656,8 +656,13 @@ int ofxAppGLFWWindowMulti::getHeight(){
 }
 
 //------------------------------------------------------------
+int ofxAppGLFWWindowMulti::getWindowMode(int winNo){
+	return ( windows[winNo]->bFullscreen ? OF_FULLSCREEN : OF_WINDOW );
+}
+
+//------------------------------------------------------------
 int	ofxAppGLFWWindowMulti::getWindowMode(){
-	return ( windows[currentWindow]->bFullscreen ? OF_FULLSCREEN : OF_WINDOW );
+    return getWindowMode(currentWindow);
 }
 
 //------------------------------------------------------------

--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -179,10 +179,10 @@ bool ofxAppGLFWWindowMulti::closeWindow(int windowNo){
             windows[windowNo]->windowPtr = NULL;
         }
         
+    } else {
+        ofLogError("ofxAppGLFWWindowMulti") << "closeWindow(): "
+            << "window doesn't exist with windowNo: " << windowNo;
     }
-
-    ofLogError("ofxAppGLFWWindowMulti") << "closeWindow(): "
-        << "window doesn't exist with windowNo: " << windowNo;
 
 	return true;
 }


### PR DESCRIPTION
This patch splits the notion of the current window into `currentWindow` for drawing, and `focusedWindow` for the currently focused window.
- Overloads basically all the `get/setWindowXXXXX` methods with a version that takes a `windowNo` argument. The original versions remain intact as oF calls them, these will always act on the `currentWindow`.
- Event callbacks are modified to set the `focusedWindow`.
- Resize callback fires for all windows, not just window `0`
- Motion callback doesn't set focused or current window, only sends for currently `focusedWindow`
  - There is a strange bug here, where if windows are created programatically (including loaded from settings), the motion callback will fire for multiple windows until window `0` is switched to. I couldn't find any way of forcing this to happen, so instead a check is included in `motion_cb` that the window making the call is focused.
- Proper fullscreen (no menu bar) now affects all monitors on OS
- Expands the `WindowManager` API to make it easier to set titles, positions, shapes, fullscreen.
  - This could be greatly expanded to make many methods easier, to access, avoiding `getWindowPtr` entirely
- Example updated for new methods

In general I think that the multi window API could be improved, we are currently working around the legacy of a single window. In particular the events should return a `windowNo` along with their values.

**Untested on Windows or Linux, should work in theory ;)**
