### PR TITLE
use glfwGetCursorPow for drop_cb

### DIFF
--- a/src/ofxAppGLFWWindowMulti.mm
+++ b/src/ofxAppGLFWWindowMulti.mm
@@ -1054,8 +1054,11 @@ void ofxAppGLFWWindowMulti::scroll_cb(GLFWwindow* windowP_, double x, double y) 
 void ofxAppGLFWWindowMulti::drop_cb(GLFWwindow* windowP_, int numFiles, const char** dropString) {
     instance->setCurrentWindowToWin(windowP_); 
 
+	double xpos, ypos;
+	glfwGetCursorPos(windowP_, &xpos, &ypos);
+
 	ofDragInfo drag;
-	drag.position.set(ofGetMouseX(), ofGetMouseY());
+	drag.position.set(xpos, ypos);
 	drag.files.resize(numFiles);
 	for(int i=0; i<(int)drag.files.size(); i++){
 		drag.files[i] = Poco::URI(dropString[i]).getPath();


### PR DESCRIPTION
because `motion_cb` doesn't get called when dragging a file, `ofGetMouseX/Y` report the position where the mouse was clicked, this fix gets the current mouse position from glfw.
